### PR TITLE
frozen string issue

### DIFF
--- a/lib/aliyun/oss/config.rb
+++ b/lib/aliyun/oss/config.rb
@@ -16,8 +16,8 @@ module Aliyun
       def initialize(opts = {})
         super(opts)
 
-        @access_key_id.strip! if @access_key_id
-        @access_key_secret.strip! if @access_key_secret
+        @access_key_id = @access_key_id.strip if @access_key_id
+        @access_key_secret = @access_key_secret.strip if @access_key_secret
         normalize_endpoint if endpoint
       end
 


### PR DESCRIPTION
如果传入的access_key_id和access_key_secret是frozen string，比如ENV["xxx"]取得的值，此处使用strip!会raise RuntimeError: can't modify frozen String，建议改为strip操作。
